### PR TITLE
Integrate Open Food Facts API

### DIFF
--- a/Controllers/OpenFoodController.cs
+++ b/Controllers/OpenFoodController.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using FitnessTracker.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FitnessTracker.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class OpenFoodController : ControllerBase
+    {
+        private readonly IOpenFoodFactsService _off;
+
+        public OpenFoodController(IOpenFoodFactsService offService)
+        {
+            _off = offService;
+        }
+
+        [HttpGet("search")]
+        public async Task<IActionResult> Search(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+                return BadRequest();
+
+            var product = await _off.SearchProductAsync(query);
+            if (product == null || product.Nutriments == null)
+                return NotFound();
+
+            return Ok(new
+            {
+                name = product.Name,
+                caloriesPer100g = product.Nutriments.EnergyKcal100g,
+                proteinPer100g = product.Nutriments.Proteins100g,
+                carbsPer100g = product.Nutriments.Carbs100g,
+                fatPer100g = product.Nutriments.Fat100g
+            });
+        }
+    }
+}

--- a/Models/OffProduct.cs
+++ b/Models/OffProduct.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace FitnessTracker.Models
+{
+    public class OffSearchResponse
+    {
+        [JsonPropertyName("products")]
+        public List<OffProduct> Products { get; set; } = new();
+    }
+
+    public class OffProduct
+    {
+        [JsonPropertyName("product_name")]
+        public string? Name { get; set; }
+
+        [JsonPropertyName("nutriments")]
+        public OffNutriments? Nutriments { get; set; }
+    }
+
+    public class OffNutriments
+    {
+        [JsonPropertyName("energy-kcal_100g")]
+        public double? EnergyKcal100g { get; set; }
+
+        [JsonPropertyName("proteins_100g")]
+        public double? Proteins100g { get; set; }
+
+        [JsonPropertyName("carbohydrates_100g")]
+        public double? Carbs100g { get; set; }
+
+        [JsonPropertyName("fat_100g")]
+        public double? Fat100g { get; set; }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -35,6 +35,11 @@ builder.Services.AddHttpClient<ICalorieService, ApiNinjasCalorieService>(c => {
     c.DefaultRequestHeaders.Add("X-Api-Key", builder.Configuration["ApiNinjas:Key"]);
 });
 
+builder.Services.AddHttpClient<IOpenFoodFactsService, OpenFoodFactsService>(c =>
+{
+    c.BaseAddress = new Uri("https://world.openfoodfacts.org/");
+});
+
 
 builder.Services.AddControllersWithViews();
 builder.Services.AddRazorPages();

--- a/Services/IOpenFoodFactsService.cs
+++ b/Services/IOpenFoodFactsService.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+using FitnessTracker.Models;
+using System.Collections.Generic;
+
+namespace FitnessTracker.Services
+{
+    public interface IOpenFoodFactsService
+    {
+        /// <summary>
+        /// Searches for a product by query and returns the first result's nutriments.
+        /// </summary>
+        Task<OffProduct?> SearchProductAsync(string query);
+    }
+}

--- a/Services/OpenFoodFactsService.cs
+++ b/Services/OpenFoodFactsService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using FitnessTracker.Models;
+
+namespace FitnessTracker.Services
+{
+    public class OpenFoodFactsService : IOpenFoodFactsService
+    {
+        private readonly HttpClient _client;
+
+        public OpenFoodFactsService(HttpClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<OffProduct?> SearchProductAsync(string query)
+        {
+            var url = $"cgi/search.pl?search_terms={Uri.EscapeDataString(query)}&search_simple=1&action=process&page_size=1&json=1";
+            try
+            {
+                using var res = await _client.GetAsync(url);
+                if (!res.IsSuccessStatusCode)
+                    return null;
+
+                var json = await res.Content.ReadAsStringAsync();
+                var data = JsonSerializer.Deserialize<OffSearchResponse>(json);
+                return data?.Products?.FirstOrDefault();
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException || ex is JsonException)
+            {
+                Console.Error.WriteLine($"OFF error: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add OpenFoodFacts client service and wire up DI
- expose `OpenFoodController` for querying nutritional info
- define models for Open Food Facts API responses

## Testing
- `dotnet restore`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6862d36011ec83239c4914a92a55d90e